### PR TITLE
NOZZLE_WIPE macro for X3 Plus

### DIFF
--- a/Plus/printer.cfg
+++ b/Plus/printer.cfg
@@ -187,6 +187,28 @@ gcode:
     PID_CALIBRATE HEATER=heater_bed TARGET=60
     SAVE_CONFIG
 
+[gcode_macro NOZZLE_WIPE]
+gcode:
+  SAVE_GCODE_STATE NAME=nozzle_wipe_state
+  SET_LED LED="hotend_neopixel" RED=1 GREEN=0 BLUE=0 SYNC=0 TRANSMIT=1
+  G90
+  {% if "xyz" not in printer.toolhead.homed_axes %}
+    G28
+  {% else %}
+  {% endif %}
+  G0 Z3 F3000         ; Raise Z slightly for safe move
+  G0 X260 Y320 F3000  ; Move to wipe start position, middle of the box
+  G0 Z0 F600          ; Lower to wipe height
+  G1 X285 F3000       ; go over the roller first
+  G1 X220 F3000       ; go over the rubber
+  {% for i in range(5) %}
+  G1 X250 F6000
+  G1 X220 F6000
+  {% endfor %}
+  G0 Z5 F3000         ; Raise Z
+  SET_LED LED="hotend_neopixel" RED=1 GREEN=1 BLUE=1 SYNC=0 TRANSMIT=1
+  RESTORE_GCODE_STATE NAME=nozzle_wipe_state
+
 [idle_timeout]
 gcode:
   {% if printer.pause_resume.is_paused %}
@@ -217,7 +239,7 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: !PB8
 position_endstop: 0
-position_max: 315
+position_max: 320
 homing_speed: 50
 
 [stepper_z]


### PR DESCRIPTION
Macro that allows wiping of the nozzle using the builtin wipe box